### PR TITLE
[TASK] Remove rename side effect

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,4 +17,4 @@ export interface PluginUserConfig {
     options?: TwigOptions
 }
 
-export default function plugin(options?: PluginUserConfig) : import('vite').Plugin
+export default function plugin(options?: PluginUserConfig) : import('vite').Plugin[]


### PR DESCRIPTION
When using an external watcher or using the watch mode from vite, the side-effect of renaming file on build start and back on build end triggers a new run indefinitly.

This change removes the renaming and tries to resolve the original file name when it detects an html file following the renaming pattern. It delegates the resolution back to vite and especially vite:resolver which originaly handled the resolution.

It also handles the file content loading as it is no more handled by vite:load-fallback, using the real file name instead of module id if known.

Remark: It can be applied to the other templating plugins.